### PR TITLE
Disable default Wiring APIimplements.

### DIFF
--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -16,6 +16,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifdef USE_WINTERRUPTS_PSEUDO_IMPLEMENT
+
 #include <contiki.h>
 #include <lib/sensors.h>
 #include <sys/process.h>
@@ -108,3 +110,6 @@ void detachInterrupt(uint32_t pin) __attribute__((weak,alias("_detachInterruptDe
 
 struct sensors_sensor* gpioPin2Button(uint32_t pin) __attribute__((weak,alias("_gpioPin2ButtonDefault")));
 struct buttonCallback* button2ButtonCallback(struct sensors_sensor*) __attribute__((weak,alias("_button2ButtonCallbackDefault")));
+
+#endif /* USE_WINTERRUPTS_PSEUDO_IMPLEMENT */
+

--- a/cores/arduino/wiring_analog.c
+++ b/cores/arduino/wiring_analog.c
@@ -16,6 +16,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifdef USE_WIRING_ANALOG_PSEUDO_IMPLEMENT
+
 #include "Arduino.h"
 #include "wiring_private.h"
 
@@ -43,3 +45,6 @@ void analogOutputInit( void ) __attribute__((weak,alias("_analogOutputInitDefaul
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* USE_WIRING_ANALOG_PSEUDO_IMPLEMENT */
+

--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -16,6 +16,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifdef USE_WIRING_DIGITAL_PSEUDO_IMPLEMENT
+
 #include "Arduino.h"
 
 #include <dev/leds.h>
@@ -65,4 +67,6 @@ int digitalRead( uint32_t ulPin ) __attribute__((weak, alias("_digitalReadDefaul
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* USE_WIRING_DIGITAL_PSEUDO_IMPLEMENT */
 


### PR DESCRIPTION
Weak function is prior resolved in same library.
Not implements Platform dependent function in core.a.

Disabled functions:

pinMode(), digitalWrite(), digitalRead()
attachInterrupt(), detachInterrupt()

analogReference(), analogWrite(), analogRead()
analogReadResolution(), analogWriteResolution()
analogOutputInit()